### PR TITLE
Use config file for config and other fixes

### DIFF
--- a/cmd/snowstorm/types/config.go
+++ b/cmd/snowstorm/types/config.go
@@ -1,0 +1,49 @@
+package types
+
+import (
+	"io/ioutil"
+
+	"gopkg.in/yaml.v2"
+)
+
+type SourceJob struct {
+	Name string
+}
+
+type Config struct {
+	// BucketName is name of the GCS bucket to use
+	BucketName string `yaml:"bucket-name"`
+
+	// MinimumFlakeCount is a count of failures to occur before we consider the failure as a flake.
+	MinimumFlakeCount int `yaml:"min-flake-count"`
+
+	// SkipFlakeAfterDays is number of days that has to pass after last observation of the flake
+	// to remove the flake from the list.
+	SkipFlakeAfterDays int `yaml:"skip-flake-after-days"`
+
+	// WorkerCount is number of workers we want to run to crawl the Gubernator. Higher number increase
+	// the concurrency but might break Gubernator ;-)
+	WorkerCount int `yaml:"worker-count"`
+
+	// IntervalSeconds is number of seconds to wait between scaping the gubernator for new builds.
+	IntervalSeconds int `yaml:"interval-seconds"`
+
+	// Depth is number of pages to process in gubernator build view
+	Depth int `yaml:"depth"`
+
+	// Jobs is a list of jobs to scape
+	Jobs []SourceJob `yaml:"source-jobs"`
+}
+
+func ParseConfig(path string) (*Config, error) {
+	configBytes, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	result := Config{}
+	err = yaml.Unmarshal(configBytes, &result)
+	if err != nil {
+		return nil, err
+	}
+	return &result, err
+}

--- a/cmd/snowstorm/types/test_suites.go
+++ b/cmd/snowstorm/types/test_suites.go
@@ -1,0 +1,99 @@
+package types
+
+import "encoding/xml"
+
+// The below types are directly marshalled into XML. The types correspond to jUnit
+// XML schema, but do not contain all valid fields. For instance, the class name
+// field for test cases is omitted, as this concept does not directly apply to Go.
+// For XML specifications see http://help.catchsoftware.com/display/ET/JUnit+Format
+// or view the XSD included in this package as 'junit.xsd'
+
+// TestSuites represents a flat collection of jUnit test suites.
+type TestSuites struct {
+	XMLName xml.Name `xml:"testsuites"`
+
+	// Suites are the jUnit test suites held in this collection
+	Suites []*TestSuite `xml:"testsuite"`
+}
+
+// TestSuite represents a single jUnit test suite, potentially holding child suites.
+type TestSuite struct {
+	XMLName xml.Name `xml:"testsuite"`
+
+	// Name is the name of the test suite
+	Name string `xml:"name,attr"`
+
+	// NumTests records the number of tests in the TestSuite
+	NumTests uint `xml:"tests,attr"`
+
+	// NumSkipped records the number of skipped tests in the suite
+	NumSkipped uint `xml:"skipped,attr"`
+
+	// NumFailed records the number of failed tests in the suite
+	NumFailed uint `xml:"failures,attr"`
+
+	// Duration is the time taken in seconds to run all tests in the suite
+	Duration float64 `xml:"time,attr"`
+
+	// Properties holds other properties of the test suite as a mapping of name to value
+	Properties []*TestSuiteProperty `xml:"properties,omitempty"`
+
+	// TestCases are the test cases contained in the test suite
+	TestCases []*TestCase `xml:"testcase"`
+
+	// Children holds nested test suites
+	Children []*TestSuite `xml:"testsuite"`
+}
+
+// TestSuiteProperty contains a mapping of a property name to a value
+type TestSuiteProperty struct {
+	XMLName xml.Name `xml:"property"`
+
+	Name  string `xml:"name,attr"`
+	Value string `xml:"value,attr"`
+}
+
+// TestCase represents a jUnit test case
+type TestCase struct {
+	XMLName xml.Name `xml:"testcase"`
+
+	// Name is the name of the test case
+	Name string `xml:"name,attr"`
+
+	// Classname is an attribute set by the package type and is required
+	Classname string `xml:"classname,attr,omitempty"`
+
+	// Duration is the time taken in seconds to run the test
+	Duration float64 `xml:"time,attr"`
+
+	// SkipMessage holds the reason why the test was skipped
+	SkipMessage *SkipMessage `xml:"skipped"`
+
+	// FailureOutput holds the output from a failing test
+	FailureOutput *FailureOutput `xml:"failure"`
+
+	// SystemOut is output written to stdout during the execution of this test case
+	SystemOut string `xml:"system-out,omitempty"`
+
+	// SystemErr is output written to stderr during the execution of this test case
+	SystemErr string `xml:"system-err,omitempty"`
+}
+
+// SkipMessage holds a message explaining why a test was skipped
+type SkipMessage struct {
+	XMLName xml.Name `xml:"skipped"`
+
+	// Message explains why the test was skipped
+	Message string `xml:"message,attr,omitempty"`
+}
+
+// FailureOutput holds the output from a failing test
+type FailureOutput struct {
+	XMLName xml.Name `xml:"failure"`
+
+	// Message holds the failure message from the test
+	Message string `xml:"message,attr"`
+
+	// Output holds verbose failure output from the test
+	Output string `xml:",chardata"`
+}

--- a/config/example.yaml
+++ b/config/example.yaml
@@ -1,0 +1,23 @@
+bucket-name: origin-ci-test
+skip-flake-after-days: 5
+min-flake-count: 2
+worker-count: 8
+interval-seconds: 1800
+depth: 5
+source-jobs:
+- name: test_branch_origin_check
+- name: test_branch_origin_cmd
+- name: test_branch_origin_cross
+- name: test_branch_origin_end_to_end
+- name: test_branch_origin_integration
+- name: test_branch_origin_verify
+- name: test_branch_origin_extended_conformance_crio
+- name: test_branch_origin_extended_conformance_gce
+- name: test_branch_origin_extended_conformance_install
+- name: test_branch_origin_extended_conformance_install_update
+- name: test_branch_origin_extended_conformance_k8s
+- name: test_branch_origin_extended_gssapi
+- name: test_branch_origin_extended_image_ecosystem
+- name: test_branch_origin_extended_ldap_groups
+- name: test_branch_origin_extended_networking
+- name: test_branch_origin_extended_templates

--- a/deploy.yaml
+++ b/deploy.yaml
@@ -40,9 +40,17 @@ items:
         containers:
         - name: snowstorm
           image: snowstorm:latest
+          command: ["/usr/bin/snowstorm", "--alsologtostderr", "-config=/etc/snowstorm/config"]
+          volumeMounts:
+          - mountPath: /etc/snowstorm
+            name: snowstorm-config
           ports:
             - name: http
               containerPort: 8080
+    volumes:
+    - name: snowstorm-config
+      configMap:
+        name: snowstorm-config
     triggers:
     - type: ConfigChange
     - imageChangeParams:

--- a/origin-configmap.yaml
+++ b/origin-configmap.yaml
@@ -1,0 +1,28 @@
+kind: ConfigMap
+metadata:
+  name: snowstorm-config
+data:
+  config: |
+    bucket-name: origin-ci-test
+    skip-flake-after-days: 14
+    min-flake-count: 2
+    worker-count: 8
+    interval-seconds: 1800
+    depth: 5
+    source-jobs:
+    - name: test_branch_origin_check
+    - name: test_branch_origin_cmd
+    - name: test_branch_origin_cross
+    - name: test_branch_origin_end_to_end
+    - name: test_branch_origin_integration
+    - name: test_branch_origin_verify
+    - name: test_branch_origin_extended_conformance_crio
+    - name: test_branch_origin_extended_conformance_gce
+    - name: test_branch_origin_extended_conformance_install
+    - name: test_branch_origin_extended_conformance_install_update
+    - name: test_branch_origin_extended_conformance_k8s
+    - name: test_branch_origin_extended_gssapi
+    - name: test_branch_origin_extended_image_ecosystem
+    - name: test_branch_origin_extended_ldap_groups
+    - name: test_branch_origin_extended_networking
+    - name: test_branch_origin_extended_templates


### PR DESCRIPTION
@stevekuznetsov this refactors the code a little so we can use config map to pass the config and the
names of jobs we feed snowstorm (so we can update/disable/etc. them without recompiling)...

Also added option to remove "old" flakes, IOW. the flakes that we haven't seen for N days (if the last occurrence of this flake was 5-10 days ago, it is likely not a flake anymore)...

For testing this locally it will help to grant anonymous access to the GCS bucket. I added `.WithoutAuthentication()` option to GCS client, but without keys it complains with:

`
E0201 14:52:13.146238   15735 main.go:355] unable to get tests for name: could not get GCS bucket name: googleapi: Error 401: Anonymous caller does not have storage.buckets.get access to origin-ci-test., required
`